### PR TITLE
Make shell depends on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@ current_dir = $(shell pwd)
 build:
 	docker build -t remind101/stacker-python-bug-squash .
 
-shell:
+shell: build
 	docker run -v $(current_dir):/usr/src/app -it remind101/stacker-python-bug-squash bash


### PR DESCRIPTION
So that it builds the image locally, instead of trying to pull it out from docker hub