### PR TITLE
Ensure the test fully consumes the mock expectations

### DIFF
--- a/lambda_hook/aws_lambda.py
+++ b/lambda_hook/aws_lambda.py
@@ -111,6 +111,7 @@ def _zip_from_file_patterns(root, includes, excludes):
     logger.info('lambda: base directory: %s', root)
 
     files = list(_find_files(root, includes, excludes))
+    files.sort()
     if not files:
         raise RuntimeError('Empty list of files for Lambda payload. Check '
                            'your include/exclude options for errors.')

--- a/lambda_hook/tests/test_lambda.py
+++ b/lambda_hook/tests/test_lambda.py
@@ -124,6 +124,7 @@ class TestLambdaHooks(unittest.TestCase):
                     aws_lambda.upload_lambda_functions(self.s3, BUCKET_NAME, "things", tmp_dir.path)
         finally:
             tmp_dir.cleanup()
+        self.stubber.assert_no_pending_responses()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The failing test will _incorrectly_ pass if you simply comment out the second call to `upload_lambda_functions` on line 124.  This should not be the case and adding the `self.stubber.assert_no_pending_responses()` should force the test to properly fail in that circumstance.  

Additionally, the files to be zipped are now sorted to _force_ a deterministic order, which is not guaranteed by the code underlying `formic.FileSet`