### PR TITLE
Run tests even if executable bit is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install -r requirements.txt
 You should now be able to run the test suite from the top level directory of the repo:
 
 ```
-nosetests
+nosetests --exe
 ```
 
 ### Docker
@@ -45,5 +45,5 @@ make shell
 
 Then directly in the docker container:
 ```
-$ nosetests
+$ nosetests --exe
 ```


### PR DESCRIPTION
Nosetests will not run tests that are contained in a file with the executable bit set.  However, if you are running in a Windows environment, or in a virtual environment and have mounted the checked out repository into the VM (docker or virtualbox or otherwise) then _all_ files will have their executable bits set.  This is a consequence of the Windows filesystem not having an explicit executable bit, thus systems that map such a Windows filesystem into a POSIX environment having to globally enable the bit for all the mapped files.

Adding `--exe` to the nosetests command should force it to consider executable files when finding tests and execute them, and should have no negative impact on systems where the executable bit is not set.

Docs for the `--exe` flag from `nosetests --help`:

> Look for tests in python modules that are executable. Normal behavior is to exclude executable modules, since they may not be import-safe [NOSE_INCLUDE_EXE]